### PR TITLE
fix(security): remove HTTPS→HTTP credential-leak fallback in zone detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Removed HTTPS→HTTP credential-leak fallback in zone detection** - The zone
+  detection logic in `py_autotask/auth.py` previously, on a 404 response,
+  retried the request over an unencrypted `http://` connection. Because the
+  session carries live API credentials (`Secret`, `UserName`,
+  `ApiIntegrationCode`) as headers, this transmitted credentials in plaintext.
+  Zone detection now only ever occurs over HTTPS; a 404 instead triggers the
+  existing heuristic fallback that selects a known HTTPS zone URL.
+
 ## [2.3.0] - 2026-02-05
 
 ### Added

--- a/py_autotask/auth.py
+++ b/py_autotask/auth.py
@@ -178,37 +178,25 @@ class AutotaskAuth:
 
             if response.status_code == 404:
                 logger.error(f"Zone detection endpoint not found at {response.url}")
-                # Try with HTTP as a fallback in case of environment-specific issues
-                # Also try without user parameter as a second fallback
-                if response.url.startswith("https://"):
-                    http_url = response.url.replace("https://", "http://", 1)
-                    logger.warning(f"Trying HTTP fallback: {http_url}")
-                    try:
-                        http_response = session.get(
-                            http_url, timeout=30, allow_redirects=True
-                        )
-                        if http_response.ok:
-                            response = http_response
-                            logger.info("HTTP fallback succeeded")
-                        else:
-                            raise AutotaskConnectionError(
-                                f"Zone detection endpoint not found at either HTTPS or HTTP.\n"
-                                f"HTTPS URL: {response.url} (404)\n"
-                                f"HTTP URL: {http_url} ({http_response.status_code})\n"
-                                "Please ensure you have the latest version of py-autotask."
-                            )
-                    except requests.exceptions.RequestException:
-                        raise AutotaskConnectionError(
-                            f"Zone detection endpoint not found. URL: {response.url}\n"
-                            "This may indicate an API endpoint change. Please ensure you have "
-                            "the latest version of py-autotask or check Autotask API documentation."
-                        )
-                else:
+                # SECURITY: never downgrade to http:// here. The session carries
+                # live API credentials (Secret/UserName/ApiIntegrationCode) and
+                # an unencrypted request would leak them in plaintext.
+                # Zone detection must only ever occur over HTTPS.
+                if not response.url.startswith("https://"):
                     raise AutotaskConnectionError(
-                        f"Zone detection endpoint not found. URL: {response.url}\n"
-                        "This may indicate an API endpoint change. Please ensure you have "
-                        "the latest version of py-autotask or check Autotask API documentation."
+                        "Zone detection refused: endpoint did not resolve over "
+                        f"HTTPS (got {response.url}). Credentialed requests are "
+                        "never sent over an unencrypted connection."
                     )
+                # The HTTPS endpoint returned 404. Fall back to heuristic zone
+                # detection over known HTTPS zone URLs rather than retrying
+                # over an insecure transport.
+                logger.warning(
+                    "HTTPS zone detection endpoint returned 404; "
+                    "using heuristic zone detection over HTTPS."
+                )
+                self._fallback_zone_detection()
+                return
             elif response.status_code == 401:
                 raise AutotaskAuthError(
                     "Authentication failed during zone detection. "
@@ -287,7 +275,9 @@ class AutotaskAuth:
     def _fallback_zone_detection(self) -> None:
         """
         Fallback zone detection using intelligent heuristics.
-        Tries HTTP if HTTPS fails as some environments may have redirect issues.
+
+        Selects a known HTTPS zone URL based on the username's email domain.
+        This never uses an unencrypted (http://) transport.
         """
         logger.info("Using fallback zone detection strategy")
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -243,32 +243,33 @@ class TestAutotaskAuth:
         assert auth._session is None
 
     @responses.activate
-    def test_zone_detection_404_with_http_fallback(self, sample_credentials):
-        """Test zone detection handles 404 and tries HTTP fallback."""
-        # Build URLs with user parameter
+    def test_zone_detection_404_uses_https_heuristic_no_http_downgrade(
+        self, sample_credentials
+    ):
+        """A 404 must NOT trigger an http:// request; credentials never leak.
+
+        On a 404 from the HTTPS zone endpoint, zone detection falls back to
+        heuristic selection of a known HTTPS zone URL. No request is ever
+        sent over an unencrypted (http://) connection.
+        """
         zone_url_with_user = (
             f"{AutotaskAuth.ZONE_INFO_URL}?user={sample_credentials.username}"
         )
 
-        # HTTPS returns 404
+        # HTTPS returns 404. Note: no http:// URL is registered, so if the
+        # code attempted an HTTP downgrade the request would raise a
+        # ConnectionError from the `responses` mock.
         responses.add(responses.GET, zone_url_with_user, status=404)
-
-        # HTTP fallback succeeds
-        http_url = zone_url_with_user.replace("https://", "http://")
-        responses.add(
-            responses.GET,
-            http_url,
-            json={
-                "url": "https://webservices123.autotask.net/atservicesrest",
-                "dataBaseType": "Production",
-                "ciLevel": "1",
-            },
-            status=200,
-        )
 
         auth = AutotaskAuth(sample_credentials)
 
-        # This should succeed with HTTP fallback
+        # Resolves via heuristic HTTPS fallback, not an HTTP downgrade.
         api_url = auth.api_url
         assert auth._zone_info is not None
-        assert api_url == "https://webservices123.autotask.net/atservicesrest"
+        assert api_url.startswith("https://")
+        assert api_url in AutotaskAuth.ZONE_URLS.values()
+
+        # Exactly one request was made (HTTPS), and it was never http://.
+        assert len(responses.calls) == 1
+        for call in responses.calls:
+            assert call.request.url.startswith("https://")


### PR DESCRIPTION
## Summary

Critical security fix. Zone detection in `py_autotask/auth.py` previously retried over an unencrypted `http://` connection on a 404. Because the session carries live API credentials (`Secret`, `UserName`, `ApiIntegrationCode`) as headers, this leaked credentials in plaintext.

## Changes
- Removed the HTTPS→HTTP downgrade fallback. A 404 from the HTTPS endpoint now triggers the existing HTTPS-only heuristic zone detection (`_fallback_zone_detection()`).
- Non-HTTPS zone endpoints are now explicitly refused with a clear error.
- Updated `tests/test_auth.py`: the 404 test now asserts no `http://` request is made and exactly one HTTPS call occurs.
- CHANGELOG `### Security` entry.

## Risk
Low. Behavior change only on the 404 path, which now uses the already-existing heuristic fallback instead of an insecure retry.