### PR TITLE
chore: relax mypy to an enforceable baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Zone detection now only ever occurs over HTTPS; a 404 instead triggers the
   existing heuristic fallback that selects a known HTTPS zone URL.
 
+### Changed
+- **mypy is now an enforceable gate.** The `[tool.mypy]` config was relaxed
+  from an always-failing strict mode (which produced thousands of pre-existing
+  errors) to a sane non-strict baseline. `mypy py_autotask/` now exits 0, so
+  type regressions are detectable. Per-module `ignore_errors` overrides cover
+  the modules with pre-existing tech debt (notably `py_autotask.entities.*`);
+  these should be removed incrementally and strict mode restored over time.
+
 ## [2.3.0] - 2026-02-05
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,29 +188,46 @@ precision = 2
 directory = "htmlcov"
 
 # MyPy configuration
+#
+# NOTE ON TYPE-CHECKING POSTURE (intentional tech debt):
+# Strict mypy (disallow_untyped_defs, disallow_incomplete_defs, etc.) was
+# previously configured but the codebase has thousands of pre-existing type
+# errors, so mypy always failed and could never serve as a CI gate.
+# This section is a deliberately relaxed *baseline* so `mypy py_autotask/`
+# passes (exit 0) and becomes a real gate that catches regressions.
+# Re-tightening toward strict mode is a future goal; flags should be
+# re-enabled incrementally as the existing errors are paid down.
 [tool.mypy]
 python_version = "3.8"
-warn_return_any = true
-warn_unused_configs = true
-disallow_untyped_defs = true
-disallow_incomplete_defs = true
-check_untyped_defs = true
-disallow_untyped_decorators = true
-no_implicit_optional = true
-warn_redundant_casts = true
-warn_unused_ignores = true
-warn_no_return = true
-warn_unreachable = true
-strict_equality = true
+ignore_missing_imports = true
+check_untyped_defs = false
 show_error_codes = true
+warn_unused_configs = true
+# Strict flags intentionally left OFF as tech-debt acknowledgement:
+#   disallow_untyped_defs, disallow_incomplete_defs,
+#   disallow_untyped_decorators, no_implicit_optional, warn_return_any,
+#   warn_redundant_casts, warn_unused_ignores, warn_no_return,
+#   warn_unreachable, strict_equality
 
+# --- Per-module tech-debt overrides ---------------------------------------
+# The modules below carry pre-existing type errors (thousands of them in
+# py_autotask.entities.*) that pre-date this baseline. They are silenced so
+# `mypy py_autotask/` exits 0 and can act as a regression gate for the rest
+# of the package. TECH DEBT: these overrides should be removed module by
+# module as the underlying errors are fixed.
 [[tool.mypy.overrides]]
 module = [
-    "requests.*",
-    "click.*",
-    "rich.*",
+    "py_autotask.entities.*",
+    "py_autotask.async_client",
+    "py_autotask.client",
+    "py_autotask.caching.*",
+    "py_autotask.pandas_integration",
+    "py_autotask.auth",
+    "py_autotask.constants",
+    "py_autotask.cache",
+    "py_autotask.bulk_manager",
 ]
-ignore_missing_imports = true
+ignore_errors = true
 
 # Bandit configuration
 [tool.bandit]


### PR DESCRIPTION
## Summary

Strict mypy was configured but the codebase has thousands of pre-existing type errors, so mypy always failed and could never act as a CI gate. This relaxes `[tool.mypy]` to a sane non-strict baseline so `mypy py_autotask/` exits 0 and catches regressions.

## Changes
- Disabled the strict flags (`disallow_untyped_defs`, `disallow_incomplete_defs`, `warn_return_any`, etc.); each is documented inline as intentional tech debt.
- Added per-module `ignore_errors` overrides for modules with pre-existing type debt (notably `py_autotask.entities.*`).
- CHANGELOG `### Changed` entry.

## Follow-up
Overrides should be removed module-by-module and strict mode restored incrementally as errors are paid down.